### PR TITLE
feat: add ChatGPT for ChatBot Feishu

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -71,6 +71,7 @@
 - [wechat-chatgpt](https://github.com/fuergaosi233/wechat-chatgpt)：ChatGPT 的微信 Bot。裝完依賴後只需要填寫 OpenAI 帳號密碼和微信掃碼就可以使用。
 - [ChatGPT LINE Bot](https://github.com/isdaviddong/chatGPTLineBot)（中文內容）：建立自己的 ChatGPT LINE 機器人。
 - [gpt-ai-assistant](https://github.com/memochou1993/gpt-ai-assistant)（中文內容）：在 10 分鐘內打造自己的 GPT LINE 機器人。
+- [chatgpt-for-chatbot-feishu](https://github.com/go-zoox/chatgpt-for-chatbot-feishu)：快速將 ChatGPT 接入飛書的應用，基於 OpenAI 官方接口 GPT3 模型，支持私有部署，作為私人工作助理或者企業員工助理。
 
 ### 反向代理網站（Reverse Proxy）
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@
 - [wechat-chatgpt](https://github.com/fuergaosi233/wechat-chatgpt): Use ChatGPT On Wechat via wechaty.
 - [ChatGPT LINE Bot](https://github.com/isdaviddong/chatGPTLineBot) (Chinese content): Build your own ChatGPT LINE bot.
 - [gpt-ai-assistant](https://github.com/memochou1993/gpt-ai-assistant) (Chinese content): Run your own GPT LINE bot on Vercel in 10 minutes.
+- [chatgpt-for-chatbot-feishu](https://github.com/go-zoox/chatgpt-for-chatbot-feishu): Connect ChatGPT with Feishu Chat Bot quickly.
 
 ### Reverse Proxy
 


### PR DESCRIPTION
###
* zh_cn: ChatGPT for ChatBot Feishu 是一个快速将 ChatGPT 接入飞书的应用，基于 OpenAI 官方接口 GPT3 模型，支持私有部署，作为私人工作助理或者企业员工助理。
* en_us: ChatGPT for ChatBot Feishu is an app for quickly integrating ChatGPT with Feishu, based on the official OpenAI interface GPT-3 model and supporting private deployment, which can be used as a personal assistant for work or an enterprise employee assistant. (Translated by it)

### Git Repo
* https://github.com/go-zoox/chatgpt-for-chatbot-feishu

### License
* MIT

### See more
* README: https://github.com/go-zoox/chatgpt-for-chatbot-feishu
* Recommand: https://github.com/ruanyf/weekly/issues/2927