### PR TITLE
Add OpenAI reverse proxy powered by Get ChatGPT Proxy https://getgptapi.com

### DIFF
--- a/README-zh-TW.md
+++ b/README-zh-TW.md
@@ -38,6 +38,10 @@
 
 ## 在任何地方使用 ChatGPT
 
+- [proxy.getgptapi.com](https://proxy.getgptapi.com/)： 免費、面翻牆、穩定可靠、安全穩定的反向代理，由 [Get ChatGPT](https://getgptapi.com) 提供
+- [proxy-1.getgptapi.com](https://proxy-1.getgptapi.com/)：免費、面翻牆、穩定可靠、安全穩定的反向代理，由 [Get ChatGPT](https://getgptapi.com) 提供
+- [proxy-2.getgptapi.com](https://proxy-2.getgptapi.com/)：免費、面翻牆、穩定可靠、安全穩定的反向代理，由 [Get ChatGPT](https://getgptapi.com) 提供
+
 ### 瀏覽器擴充套件
 
 - [ChatGPT for Google](https://chrome.google.com/webstore/detail/chatgpt-for-google/jgjaeacdkonaoafenlfkkkmbaopkbilf)：Chrome/Edge/Firefox 瀏覽器擴充套件，在 Google 搜索結果旁並列 ChatGPT 回應。（[Firefox擴充套件](https://addons.mozilla.org/en-US/firefox/addon/chatgpt-for-google/)、[程式碼](https://github.com/wong2/chat-gpt-google-extension)）


### PR DESCRIPTION
免費、面翻牆、穩定可靠、安全穩定的反向代理，由  https://getgptapi.com/ 提供